### PR TITLE
Python ccm and kubevip load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ The following table lists the configuration variables for both templates:
 
 | Variable | Description | Default Value |
 |----------|-------------|---------------|
-| organization | The Equinix Metal organization ID. This variable is required. | N/A           |
+| organization | The Equinix Metal organization ID under which you want to create the project. This variable is optional. If you leave it out, the project will be create under the default organization of your account.| N/A           |
 | project | The Equinix Metal project ID. This variable is optional. If not specified, a new project will be created. | N/A           |
-| metro   | The deployment metro code. This variable is optional and defaults to 'SV'. See [metro codes](https://deploy.equinix.com/developers/docs/metal/locations/metros/#metros-quick-reference) | SV            |
+| metro   | The deployment metro code. This variable is optional. See [metro codes](https://deploy.equinix.com/developers/docs/metal/locations/metros/#metros-quick-reference) | SV            |
 | sshPrivateKeyPath | Path to a private key of an existing Equinix Metal SSH Key. This variable is optional. If not specified, a new project Equinix Metal SSH Key will be created. | N/A           |
-| kubernetesVersion  | The Kubernetes version. This variable is optional and defaults to '1.24.7'. | 1.24.7         |
+| kubernetesVersion  | The Kubernetes version. This variable is optional. | 1.24.7         |
 
 To add them you can use `pulumi config set` command:
 

--- a/nodejs/Pulumi.yaml
+++ b/nodejs/Pulumi.yaml
@@ -1,4 +1,4 @@
-name: metal-k8s-cluster
+name: equinix-ts-metal-k8s-cluster
 runtime: nodejs
 description: A Node.js Pulumi template for Kubernetes on Equinix Metal with kubeadm and cloud-init
 main: src/index.ts

--- a/python/Pulumi.yaml
+++ b/python/Pulumi.yaml
@@ -1,4 +1,4 @@
-name: metal-k8s-cluster
+name: equinix-py-metal-k8s-cluster
 runtime: python
 description: A python Pulumi template for Kubernetes on Equinix Metal with kubeadm and cloud-init
 main: src/__main__.py

--- a/python/cloud-init/scripts/ccm-cloud-provider-equinix-metal.sh
+++ b/python/cloud-init/scripts/ccm-cloud-provider-equinix-metal.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -e
+
+# NOTE: To use CCM all kubelets in your cluster must set the flag --cloud-provider=external.
+# This has been removed from this script and included in ./kubernetes-kubeadm-cp-config.sh and ./kubernetes-kubeadm-worker-config.sh
+# If CPEM installation is removed from cloud-init config scripts should be updated accordingly
+# More info https://github.com/equinix/cloud-provider-equinix-metal#kubernetes-binary-arguments
+
+echo "Install CPEM..."
+
+CONTROL_PLANE_ROLE=$(jq -r ".controlPlaneRole" /run/customdata.json)
+if ! [[ "${CONTROL_PLANE_ROLE}" == "primary" ]]; then
+  exit 0
+fi
+
+CPEM_VERSION="v3.6.2"
+API_KEY=$(jq -r ".ccmApiKey" /run/customdata.json)
+PROJECT=$(jq -r ".projectId" /run/customdata.json)
+METRO=$(jq -r ".metro" /run/metadata.json)
+LOAD_BALANCER="kube-vip://"
+
+# create a secret to store required Equinix Metal configuration
+cat << EOF > /tmp/equinix-ccm-config.yaml
+apiVersion: v1
+kind: Secret 
+metadata:
+  name: metal-cloud-config
+  namespace: kube-system
+stringData:
+  cloud-sa.json: |
+    {
+      "apiKey": "${API_KEY}",
+      "projectID": "${PROJECT}",
+      "metro": "${METRO}",
+      "loadbalancer": "${LOAD_BALANCER}"
+    }
+EOF
+kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /tmp/equinix-ccm-config.yaml
+rm /tmp/equinix-ccm-config.yaml
+
+# deploy cloud-provider-equinix-metal
+URL="https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION}/deployment.yaml"
+kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f $URL

--- a/python/cloud-init/scripts/kube-vip-cp-ha-bgp.sh
+++ b/python/cloud-init/scripts/kube-vip-cp-ha-bgp.sh
@@ -4,7 +4,7 @@ set -e
 echo "Install kube-vip for HA..."
 
 CONTROL_PLANE_IP=$(jq -r ".controlPlaneIp" /run/customdata.json)
-KUBE_VIP_VERSION="v0.5.12" #TODO $(jq -r ".kubeVipVersion" /run/customdata.json)
+KUBE_VIP_VERSION="v0.5.12" #TODO (ocobleseqx) should it be customisable $(jq -r ".kubeVipVersion" /run/customdata.json)?
 
 ctr image pull ghcr.io/kube-vip/kube-vip:${KUBE_VIP_VERSION}
 ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:${KUBE_VIP_VERSION} vip /kube-vip manifest pod \

--- a/python/cloud-init/scripts/kube-vip-lb-services.sh
+++ b/python/cloud-init/scripts/kube-vip-lb-services.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Install kube-vip for Load Balancing..."
+
+IMAGE=ghcr.io/kube-vip/kube-vip:v0.6.0
+kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f https://kube-vip.io/manifests/rbac.yaml
+ctr i pull $IMAGE
+ctr run --rm --net-host $IMAGE vip /kube-vip manifest daemonset \
+--interface lo \
+--services \
+--bgp \
+--annotations metal.equinix.com \
+--inCluster | kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f -
+

--- a/python/cloud-init/scripts/kubelet-config.sh
+++ b/python/cloud-init/scripts/kubelet-config.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-echo "Kubelet config..."
-
-PRIVATE_IPv4=$(curl -s https://metadata.platformequinix.com/metadata | jq -r '.network.addresses | map(select(.public==false and .management==true)) | first | .address')
-
-echo "KUBELET_EXTRA_ARGS=--node-ip=${PRIVATE_IPv4}" > /etc/default/kubelet

--- a/python/cloud-init/scripts/kubernetes-kubeadm-cp-config.sh
+++ b/python/cloud-init/scripts/kubernetes-kubeadm-cp-config.sh
@@ -6,7 +6,7 @@ echo "Kubeadm config..."
 KUBERNETES_VERSION=$(jq -r ".kubernetesVersion" /run/customdata.json)
 JOIN_TOKEN=$(jq -r ".joinToken" /run/customdata.json)
 CONTROL_PLANE_IP=$(jq -r ".controlPlaneIp" /run/customdata.json)
-PRIVATE_IPv4=$(jq -r '.network.addresses | map(select(.public==false and .management==true)) | first | .address' /run/customdata.json)
+PRIVATE_IPv4=$(jq -r '.network.addresses | map(select(.public==false and .management==true)) | first | .address' /run/metadata.json)
 
 cat > /etc/kubernetes/init.yaml <<EOF
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/python/cloud-init/scripts/kubernetes-kubeadm-cp-config.sh
+++ b/python/cloud-init/scripts/kubernetes-kubeadm-cp-config.sh
@@ -21,6 +21,7 @@ localAPIEndpoint:
 nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: "external"
+    node-ip: "${PRIVATE_IPv4}"
   taints: null
 bootstrapTokens:
 - token: ${JOIN_TOKEN}
@@ -46,6 +47,7 @@ kind: JoinConfiguration
 nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: "external"
+    node-ip: "${PRIVATE_IPv4}"
   taints: null
 discovery:
   bootstrapToken:

--- a/python/cloud-init/scripts/kubernetes-kubeadm-cp-config.sh
+++ b/python/cloud-init/scripts/kubernetes-kubeadm-cp-config.sh
@@ -6,7 +6,7 @@ echo "Kubeadm config..."
 KUBERNETES_VERSION=$(jq -r ".kubernetesVersion" /run/customdata.json)
 JOIN_TOKEN=$(jq -r ".joinToken" /run/customdata.json)
 CONTROL_PLANE_IP=$(jq -r ".controlPlaneIp" /run/customdata.json)
-PRIVATE_IPv4=$(curl -s https://metadata.platformequinix.com/metadata | jq -r '.network.addresses | map(select(.public==false and .management==true)) | first | .address')
+PRIVATE_IPv4=$(jq -r '.network.addresses | map(select(.public==false and .management==true)) | first | .address' /run/customdata.json)
 
 cat > /etc/kubernetes/init.yaml <<EOF
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/python/cloud-init/scripts/kubernetes-kubeadm-cp-join.sh
+++ b/python/cloud-init/scripts/kubernetes-kubeadm-cp-join.sh
@@ -10,7 +10,7 @@ systemctl enable kubelet.service
 if [[ "${CONTROL_PLANE_ROLE}" == "primary" ]];
 then
   kubeadm init --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,FileAvailable--etc-kubernetes-pki-ca.crt \
-    --skip-phases=addon/kube-proxy --config=/etc/kubernetes/init.yaml
+    --config=/etc/kubernetes/init.yaml
 else
   kubeadm join --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,FileAvailable--etc-kubernetes-pki-ca.crt \
     --config=/etc/kubernetes/join.yaml

--- a/python/cloud-init/scripts/kubernetes-kubeadm-worker-config.sh
+++ b/python/cloud-init/scripts/kubernetes-kubeadm-worker-config.sh
@@ -5,6 +5,7 @@ echo "Kubeadm config..."
 
 JOIN_TOKEN=$(jq -r ".joinToken" /run/customdata.json)
 CONTROL_PLANE_IP=$(jq -r ".controlPlaneIp" /run/customdata.json)
+PRIVATE_IPv4=$(curl -s https://metadata.platformequinix.com/metadata | jq -r '.network.addresses | map(select(.public==false and .management==true)) | first | .address')
 
 mkdir -p /etc/kubernetes/
 
@@ -14,6 +15,7 @@ kind: JoinConfiguration
 nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: "external"
+    node-ip: "${PRIVATE_IPv4}"
   taints: null
 discovery:
   bootstrapToken:

--- a/python/cloud-init/scripts/kubernetes-kubeadm-worker-config.sh
+++ b/python/cloud-init/scripts/kubernetes-kubeadm-worker-config.sh
@@ -5,11 +5,11 @@ echo "Kubeadm config..."
 
 JOIN_TOKEN=$(jq -r ".joinToken" /run/customdata.json)
 CONTROL_PLANE_IP=$(jq -r ".controlPlaneIp" /run/customdata.json)
-PRIVATE_IPv4=$(curl -s https://metadata.platformequinix.com/metadata | jq -r '.network.addresses | map(select(.public==false and .management==true)) | first | .address')
+PRIVATE_IPv4=$(jq -r '.network.addresses | map(select(.public==false and .management==true)) | first | .address' /run/metadata.json)
 
 mkdir -p /etc/kubernetes/
 
-cat <<EOF > /etc/kubernetes/join.yaml
+cat > /etc/kubernetes/join.yaml <<EOF
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: JoinConfiguration
 nodeRegistration:

--- a/python/cloud-init/scripts/kubernetes-kubeadm-worker-join.sh
+++ b/python/cloud-init/scripts/kubernetes-kubeadm-worker-join.sh
@@ -3,11 +3,8 @@ set -e
 
 echo "Execute kubeadm join..."
 
-CONTROL_PLANE_IP=$(jq -r ".controlPlaneIp" /run/customdata.json)
-JOIN_TOKEN=$(jq -r ".joinToken" /run/customdata.json)
-
 systemctl enable kubelet.service
 
-kubeadm join --token $JOIN_TOKEN --discovery-token-unsafe-skip-ca-verification $CONTROL_PLANE_IP:6443
+kubeadm join --config=/etc/kubernetes/join.yaml
 
 rm /etc/kubernetes/join.yaml

--- a/python/cloud-init/scripts/network-config-cp.sh
+++ b/python/cloud-init/scripts/network-config-cp.sh
@@ -11,7 +11,6 @@ then
   ip addr add ${CONTROL_PLANE_IP} dev lo
 fi
 
-curl -o /run/metadata.json --retry 10 -fsSL https://metadata.platformequinix.com/metadata
-for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
+for i in $(jq -r '.bgp_neighbors[0].peer_ips[]' /run/metadata.json); do
   ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
 done

--- a/python/cloud-init/scripts/network-config-worker.sh
+++ b/python/cloud-init/scripts/network-config-worker.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Network config..."
+
+GATEWAY_IP=$(jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway' /run/metadata.json)
+for i in $(jq -r '.bgp_neighbors[0].peer_ips[]' /run/metadata.json); do
+  ip route add $i via $GATEWAY_IP
+done

--- a/python/src/__main__.py
+++ b/python/src/__main__.py
@@ -17,7 +17,7 @@ def create_project() -> equinix.metal.Project:
     return equinix.metal.Project(
         "example",
         name="pulumi-k8s",
-        organization_id=config.require_secret("organization"),
+        organization_id=config.get("organization"),
         bgp_config=equinix.metal.ProjectBgpConfigArgs(
             deployment_type="local",
             asn=65000,
@@ -55,9 +55,9 @@ def create_project_key(
 
 # Get configuration values
 config = pulumi.Config()
-kubernetes_version = config.get("kubernetesVersion") or "1.24.7"
-metal_metro = config.get("metro") or "SV"
-project_id = config.get("project") or create_project().id
+kubernetes_version = config.get("kubernetesVersion", "1.24.7")
+metal_metro = config.get("metro", "SV")
+project_id = config.get("project", create_project().id)
 ssh_private_key_path = config.get("sshPrivateKeyPath")
 private_ssh_key = (
     create_project_key("pulumi-k8s-metal-ssh-key", project_id)

--- a/python/src/__main__.py
+++ b/python/src/__main__.py
@@ -4,7 +4,7 @@ import sys
 import pulumi
 import pulumi_equinix as equinix
 import pulumi_tls as tls
-from pulumi import Input, Output, ResourceOptions
+from pulumi import Input, Output
 
 sys.path.insert(0, os.getcwd())
 from kubernetes.cluster import Cluster
@@ -88,3 +88,19 @@ cluster = Cluster(
 )
 
 pulumi.export("kubeconfig", cluster.control_plane.kubeconfig)
+
+cp_nodes = {
+    node.device.hostname: node.device.access_public_ipv4
+    for node in cluster.control_plane.control_plane_devices
+}
+pulumi.export("controlPlaneDeviceIps", Output.all(cp_nodes))
+
+
+worker_pools = {}
+for name, pool in cluster.worker_pools.items():
+    worker_pools[name] = {
+        node.device.hostname: node.device.access_public_ipv4
+        for node in pool.worker_nodes
+    }
+
+pulumi.export("WorkerPoolsDeviceIps", Output.all(worker_pools))

--- a/python/src/kubernetes/cluster.py
+++ b/python/src/kubernetes/cluster.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Any, Dict
+from typing import Dict
 
 import pulumi_equinix as equinix
 
@@ -8,7 +8,6 @@ sys.path.insert(0, os.getcwd())
 
 from typing import Optional
 
-import pulumi
 from kubernetes.controlplane.main import Config as ControlPlaneConfig
 from kubernetes.controlplane.main import ControlPlane
 from kubernetes.meta import PREFIX
@@ -55,9 +54,16 @@ class Cluster(ComponentResource):
 
         self.worker_pools: Dict[str, WorkerPool] = {}
         for worker_config in config.worker_pool_configs:
-            self.__create_worker_pool(worker_config.name_suffix, worker_config)
+            self.__create_worker_pool(worker_config)
 
-        self.register_outputs({"kubeconfig": self.control_plane.kubeconfig})
+        self.register_outputs(
+            {
+                "kubeconfig": self.control_plane.kubeconfig,
+                "controlPlaneDevices": self.control_plane.control_plane_devices,
+                "workerPools": self.worker_pools,
+            }
+        )
 
-    def __create_worker_pool(self, name: str, config: WorkerPoolConfig):
-        self.worker_pools[name] = WorkerPool(self, config)
+    def __create_worker_pool(self, config: WorkerPoolConfig):
+        wp = WorkerPool(self, config)
+        self.worker_pools[wp.name] = wp

--- a/python/src/kubernetes/controlplane/cloud_config.py
+++ b/python/src/kubernetes/controlplane/cloud_config.py
@@ -98,6 +98,12 @@ cloud_config = cloudinit.get_config(
         cloudinit.GetConfigPartArgs(
             content_type="text/x-shellscript",
             content=helpers.get_file_content(
+                f"{helpers.get_project_root()}/cloud-init/scripts/kube-vip-lb-services.sh"
+            ),
+        ),
+        cloudinit.GetConfigPartArgs(
+            content_type="text/x-shellscript",
+            content=helpers.get_file_content(
                 f"{helpers.get_project_root()}/cloud-init/scripts/net-deny-metadata.sh"
             ),
         ),

--- a/python/src/kubernetes/controlplane/cloud_config.py
+++ b/python/src/kubernetes/controlplane/cloud_config.py
@@ -50,12 +50,6 @@ cloud_config = cloudinit.get_config(
         cloudinit.GetConfigPartArgs(
             content_type="text/x-shellscript",
             content=helpers.get_file_content(
-                f"{helpers.get_project_root()}/cloud-init/scripts/kubelet-config.sh"
-            ),
-        ),
-        cloudinit.GetConfigPartArgs(
-            content_type="text/x-shellscript",
-            content=helpers.get_file_content(
                 f"{helpers.get_project_root()}/cloud-init/scripts/kubernetes-kubeadm-certs.sh"
             ),
         ),
@@ -93,6 +87,12 @@ cloud_config = cloudinit.get_config(
             content_type="text/x-shellscript",
             content=helpers.get_file_content(
                 f"{helpers.get_project_root()}/cloud-init/scripts/cni-cilium.sh"
+            ),
+        ),
+        cloudinit.GetConfigPartArgs(
+            content_type="text/x-shellscript",
+            content=helpers.get_file_content(
+                f"{helpers.get_project_root()}/cloud-init/scripts/ccm-cloud-provider-equinix-metal.sh"
             ),
         ),
         cloudinit.GetConfigPartArgs(

--- a/python/src/kubernetes/controlplane/main.py
+++ b/python/src/kubernetes/controlplane/main.py
@@ -53,6 +53,14 @@ class ControlPlane(ComponentResource):
 
         self.join_token = JoinToken(self)
 
+        self.ccm_api_key = equinix.metal.ProjectApiKey(
+            f"{self.cluster.name}-api-key",
+            project_id=self.cluster.config.project,
+            description="API Key for Kubernetes CCM cloud-provider-equinix-metal",
+            read_only=False,
+            opts=ResourceOptions(parent=self),
+        )
+
         self.control_plane_devices = []
         control_plane1 = self.__create_device(1)
         self.control_plane_devices.append(control_plane1)
@@ -64,14 +72,14 @@ class ControlPlane(ComponentResource):
         )
 
         wait_cloudinit = command.remote.Command(
-            "wait-cloud-init",
+            f"{self.cluster.name}-wait-cloud-init",
             connection=conn,
             create="cloud-init status --wait",
             opts=ResourceOptions(parent=self, depends_on=[control_plane1.device]),
         )
 
         self.kubeconfig = command.remote.Command(
-            "kubeconfig",
+            f"{self.cluster.name}-kubeconfig",
             connection=conn,
             create="cat /root/.kube/config",
             opts=ResourceOptions(
@@ -115,6 +123,8 @@ class ControlPlane(ComponentResource):
                 self.front_proxy_certificate.certificate.cert_pem,
                 self.etcd_certificate.private_key.private_key_pem,
                 self.etcd_certificate.certificate.cert_pem,
+                self.cluster.config.project,
+                self.ccm_api_key.token,
             ).apply(
                 lambda values: Output.json_dumps(
                     {
@@ -130,6 +140,8 @@ class ControlPlane(ComponentResource):
                         "frontProxyCert": values[7],
                         "etcdKey": values[8],
                         "etcdCert": values[9],
+                        "projectId": values[10],
+                        "ccmApiKey": values[11] if i == 1 else "",
                     },
                     separators=(",", ":"),
                 )

--- a/python/src/kubernetes/controlplane/main.py
+++ b/python/src/kubernetes/controlplane/main.py
@@ -17,6 +17,7 @@ class Config:
         self.high_availability = high_availability
 
 
+@input_type
 class ControlPlaneNode:
     def __init__(
         self, device: equinix.metal.Device, bgp_session: equinix.metal.BgpSession
@@ -101,7 +102,7 @@ class ControlPlane(ComponentResource):
 
     def __create_device(
         self, i: int, depends_on: List[equinix.metal.Device] = []
-    ) -> ControlPlaneNode:
+    ) -> Output[ControlPlaneNode]:
         hostname = f"{self.cluster.name}-control-plane-{i}"
 
         device = equinix.metal.Device(
@@ -157,4 +158,6 @@ class ControlPlane(ComponentResource):
             opts=ResourceOptions(parent=self, depends_on=[device]),
         )
 
-        return ControlPlaneNode(device=device, bgp_session=bgp_session)
+        return Output.from_input(
+            ControlPlaneNode(device=device, bgp_session=bgp_session)
+        )

--- a/python/src/kubernetes/worker_pool.py
+++ b/python/src/kubernetes/worker_pool.py
@@ -100,12 +100,6 @@ cloud_config = cloudinit.get_config(
         cloudinit.ConfigPartArgs(
             content_type="text/x-shellscript",
             content=helpers.get_file_content(
-                f"{helpers.get_project_root()}/cloud-init/scripts/kubelet-config.sh"
-            ),
-        ),
-        cloudinit.ConfigPartArgs(
-            content_type="text/x-shellscript",
-            content=helpers.get_file_content(
                 f"{helpers.get_project_root()}/cloud-init/scripts/kubernetes-kubeadm-packages.sh"
             ),
         ),

--- a/python/src/kubernetes/worker_pool.py
+++ b/python/src/kubernetes/worker_pool.py
@@ -85,6 +85,12 @@ cloud_config = cloudinit.get_config(
                 f"{helpers.get_project_root()}/cloud-init/scripts/download-metadata.sh"
             ),
         ),
+        cloudinit.GetConfigPartArgs(
+            content_type="text/x-shellscript",
+            content=helpers.get_file_content(
+                f"{helpers.get_project_root()}/cloud-init/scripts/network-config-worker.sh"
+            ),
+        ),
         cloudinit.ConfigPartArgs(
             content_type="text/x-shellscript",
             content=helpers.get_file_content(


### PR DESCRIPTION
- Renamed stacks to have different names for the different languages since a project can only be in 1 language
- Organization ID is now optional as it is for Equinix.metal.Project
- Fix kube-proxy/cni installation, there was a flag to skip kube-proxy installation and CNI was replacing just some of the proxy functions
- Fix networking for workers, added routes for bgp neighbors (required for LB)
- Added CPEM v3.6.2
- Added Kube-vip v0.6.0 for LB
- API key for CPEM created on the fly
- Exported device information in outputs
